### PR TITLE
Add support to specify server locator with name instead of IP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,39 @@
 FROM ros:galactic
 
-# install ros package
+# Use bash instead of sh for the RUN steps
+SHELL ["/bin/bash", "-c"]
+
+# Install ros packages and dependencies
 RUN apt-get update && apt-get install -y \
-    ros-${ROS_DISTRO}-rmw-fastrtps-cpp \
-    ros-${ROS_DISTRO}-demo-nodes-py && \
+    # Fast DDS dependencies
+    libssl-dev \
+    libasio-dev \
+    # Demo packages
+    ros-${ROS_DISTRO}-demo-nodes-cpp
+
+# Build Fast DDS and rmw_fastrtps from sources. This is because specifying IP addresses using names
+# is only supported in Fast DDS v2.4.0 and onwards, but ROS 2 Galactic binary installation ships
+# Fast DDS v2.3.4. Since Fast DDS v2.3.4 and v2.4.0 are not binary compatible, the three packages
+# rmw_fastrtps_shared_cpp, rmw_fastrtps_cpp, and rmw_fastrtps_dynamic_cpp need to be built as well.
+# The rmw_fastrtps_* packages are contained in the rmw_fastrtps repository, for which Galactic ships
+# 5.0.0, which is what is built here. If this project is upgraded to ROS 2 Humble, all this can be
+# removed, as Humble will ship Fast DDS v2.6.0, and in fact rmw_fastrtps_cpp will be the default
+# rmw implementation, so it will be already installed in the ros:humble Docker image.
+WORKDIR /fastdds_overlay
+COPY fastdds.repos colcon.meta /fastdds_overlay/
+RUN source /opt/ros/galactic/setup.bash && \
+    # Download sources
+    mkdir src && \
+    vcs import src < fastdds.repos && \
+    # Install rmw_fastrtps_cpp dependencies without installing ros-galactic-rmw-fastrtps-cpp
+    sed -i 's/ros-'$ROS_DISTRO'-rmw-cyclonedds-cpp | ros-'$ROS_DISTRO'-rmw-connextdds | ros-'$ROS_DISTRO'-rmw-fastrtps-cpp/ros-'$ROS_DISTRO'-rmw-dds-common/' /var/lib/dpkg/status && \
+    rosdep update --rosdistro $ROS_DISTRO && \
+    rosdep install --from-paths src --ignore-src -y && \
+    # Build overlay
+    colcon build && \
+    # Cleanup
+    apt autoremove -y && \
+    rm -rf log/ build/ src/ colcon.meta fastdds.repos && \
     rm -rf /var/lib/apt/lists/*
 
 COPY fastdds_server.xml /

--- a/colcon.meta
+++ b/colcon.meta
@@ -1,0 +1,33 @@
+{
+    "names":
+    {
+        "fastrtps":
+        {
+            "cmake-args":
+            [
+                "-DSECURITY=ON"
+            ]
+        },
+        "rmw_fastrtps_shared_cpp":
+        {
+            "cmake-args":
+            [
+                "-DSECURITY=ON"
+            ]
+        },
+        "rmw_fastrtps_dynamic_cpp":
+        {
+            "cmake-args":
+            [
+                "-DSECURITY=ON"
+            ]
+        },
+        "rmw_fastrtps_cpp":
+        {
+            "cmake-args":
+            [
+                "-DSECURITY=ON"
+            ]
+        }
+    }
+}

--- a/docker-compose.discovery-server.yml
+++ b/docker-compose.discovery-server.yml
@@ -1,4 +1,4 @@
-# TL;DR 
+# TL;DR
 # docker-compose -f docker-compose.discovery-server.yml up
 
 version: '2.3'
@@ -13,9 +13,10 @@ services:
       - bash
       - -c
       - |
+          source /fastdds_overlay/install/setup.bash
           export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
           export FASTRTPS_DEFAULT_PROFILES_FILE=/fastdds_server.xml
-          ros2 run demo_nodes_py listener
+          ros2 run demo_nodes_cpp listener
 
   husarnet-discovery-server:
     image: husarnet/husarnet
@@ -28,7 +29,7 @@ services:
       - NET_ADMIN
     devices:
       - /dev/net/tun
-    environment: 
+    environment:
       - HOSTNAME=ddsdiscoveryserver
-    env_file: 
+    env_file:
       - ./.env  # create .env file in the same folder

--- a/docker-compose.listener.yml
+++ b/docker-compose.listener.yml
@@ -1,4 +1,4 @@
-# TL;DR 
+# TL;DR
 # docker-compose -f docker-compose.listener.yml up
 
 version: '2.3'
@@ -13,9 +13,10 @@ services:
       - bash
       - -c
       - |
+          source /fastdds_overlay/install/setup.bash
           export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
           export FASTRTPS_DEFAULT_PROFILES_FILE=/fastdds_client.xml
-          ros2 run demo_nodes_py listener
+          ros2 run demo_nodes_cpp listener
 
   husarnet-listener:
     image: husarnet/husarnet
@@ -28,7 +29,7 @@ services:
       - NET_ADMIN
     devices:
       - /dev/net/tun
-    environment: 
+    environment:
       - HOSTNAME=listener
-    env_file: 
+    env_file:
       - ./.env  # create .env file in the same folder

--- a/docker-compose.talker.yml
+++ b/docker-compose.talker.yml
@@ -1,4 +1,4 @@
-# TL;DR 
+# TL;DR
 # docker-compose -f docker-compose.talker.yml up
 
 version: '2.3'
@@ -13,9 +13,10 @@ services:
       - bash
       - -c
       - |
+          source /fastdds_overlay/install/setup.bash
           export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
           export FASTRTPS_DEFAULT_PROFILES_FILE=/fastdds_client.xml
-          ros2 run demo_nodes_py talker
+          ros2 run demo_nodes_cpp talker
 
   husarnet-talker:
     image: husarnet/husarnet
@@ -28,8 +29,7 @@ services:
       - NET_ADMIN
     devices:
       - /dev/net/tun
-    environment: 
+    environment:
       - HOSTNAME=talker
-    env_file: 
+    env_file:
       - ./.env  # create .env file in the same folder
-

--- a/fastdds.repos
+++ b/fastdds.repos
@@ -1,0 +1,21 @@
+repositories:
+    foonathan_memory_vendor:
+        type: git
+        url: https://github.com/eProsima/foonathan_memory_vendor.git
+        version: v1.1.0
+    fastcdr:
+        type: git
+        url: https://github.com/eProsima/Fast-CDR.git
+        version: v1.0.22
+    fastrtps:
+        type: git
+        url: https://github.com/eProsima/Fast-DDS.git
+        version: v2.4.0
+    rmw_fastrtps:
+        type: git
+        url: https://github.com/ros2/rmw_fastrtps.git
+        version: 5.0.0
+    rosidl_typesupport_fastrtps:
+        type: git
+        url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
+        version: 1.2.1


### PR DESCRIPTION
This PR adds support for specifying the Discovery Server IPv6 address using a name instead of a full address. It does so by building Fast DDS v2.4.1 from sources, since this feature was added in Fast DDS v2.4.0.

Signed-off-by: Eduardo Ponz <eduardoponz@eprosima.com>